### PR TITLE
Theme redesign: type system, glass panels, unified hover/focus

### DIFF
--- a/index.html
+++ b/index.html
@@ -923,7 +923,8 @@
     .project-step-label, .flip-number, .metric, #readme-container{
       font-family:var(--font-mono)!important;
     }
-    .scholar-value{ color:var(--accent-2)!important; }
+    .scholar-value{ color:var(--accent-2)!important; text-align:right; }
+    .scholar-item{ display:flex; justify-content:space-between; align-items:baseline; gap:12px; }
     #quake-panel h3{ font-family:var(--font-head); }
 
     /* tagline + profile */

--- a/index.html
+++ b/index.html
@@ -4,7 +4,12 @@
   <meta charset="UTF-8" />
   <title>Debajeet Barman – Geophysicist</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  
+
+  <!-- Fonts -->
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Space+Grotesk:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+
   <style>
 @keyframes flipDigits {
   0% {
@@ -827,6 +832,117 @@
   text-shadow: 0 0 8px rgba(0,255,255,0.4);
   text-align: center;
 }
+
+
+    /* ============================================================
+       THEME REFRESH — typography, glass panels, unified states
+       Layered overrides; original rules above remain as fallback.
+       ============================================================ */
+    :root{
+      --accent:#2ee6ff;
+      --accent-2:#8af4ff;
+      --ink:#e9f6f9;
+      --muted:#9db4bb;
+      --panel:linear-gradient(158deg, rgba(11,22,28,0.74), rgba(4,10,14,0.60));
+      --panel-brd:rgba(46,230,255,0.28);
+      --glow-md:0 6px 30px rgba(0,0,0,0.45), 0 0 26px rgba(46,230,255,0.20);
+      --radius:16px;
+      --font-head:'Space Grotesk','Segoe UI',system-ui,sans-serif;
+      --font-body:'Inter',system-ui,-apple-system,'Segoe UI',Roboto,sans-serif;
+      --font-mono:'JetBrains Mono','Courier New',ui-monospace,monospace;
+    }
+
+    /* base */
+    body{
+      font-family:var(--font-body);
+      color:var(--ink);
+      background:
+        radial-gradient(1200px 820px at 80% -12%, rgba(46,230,255,0.12), transparent 60%),
+        radial-gradient(900px 720px at 8% 112%, rgba(138,244,255,0.08), transparent 55%),
+        linear-gradient(180deg,#03080c 0%, #050b11 55%, #02060a 100%);
+      background-attachment:fixed;
+      -webkit-font-smoothing:antialiased;
+      text-rendering:optimizeLegibility;
+    }
+
+    /* headings */
+    .tab-section h1{
+      font-family:var(--font-head);
+      font-weight:600;
+      letter-spacing:.4px;
+      font-size:clamp(1.6rem,2.4vw,2.2rem);
+      color:var(--accent-2)!important;
+      text-shadow:0 0 18px rgba(46,230,255,.5);
+    }
+    .project-meta h2, .panel-card h3, .slide h3{
+      font-family:var(--font-head); color:var(--accent-2)!important; letter-spacing:.2px;
+    }
+    .project-meta h4{ font-family:var(--font-head); color:var(--muted); }
+
+    /* shared glass surface */
+    .tab-section, .about-scroll, .panel-card, .project-slide, .github-panel,
+    .slide, .info-card, #quake-panel, #scholar-box, #pub-world, .mini-3d-wrapper{
+      background:var(--panel)!important;
+      border:1px solid var(--panel-brd);
+      border-radius:var(--radius);
+      box-shadow:var(--glow-md);
+      -webkit-backdrop-filter:blur(14px) saturate(125%);
+      backdrop-filter:blur(14px) saturate(125%);
+    }
+    .tab-section{ padding:clamp(26px,3.5vw,46px)!important; }
+
+    /* tabs */
+    .tabs-nav{
+      background:linear-gradient(180deg, rgba(7,16,22,.86), rgba(4,10,14,.72))!important;
+      border:1px solid var(--panel-brd);
+      box-shadow:var(--glow-md);
+    }
+    .tab-link{
+      font-family:var(--font-head); font-weight:500; letter-spacing:.3px;
+      transition:background .22s ease,color .22s ease,box-shadow .22s ease,transform .22s ease;
+    }
+    .tab-link:hover{ background:rgba(46,230,255,.12); color:var(--accent-2); transform:translateY(-1px); }
+    .tab-link.active{
+      background:linear-gradient(180deg, rgba(46,230,255,.30), rgba(46,230,255,.12));
+      border-color:var(--accent); color:#eafcff;
+      box-shadow:0 0 18px rgba(46,230,255,.45);
+    }
+
+    /* cards: unified hover */
+    .panel-card, .contact-card, .project-slide{
+      transition:transform .25s ease, box-shadow .25s ease, border-color .25s ease;
+    }
+    .panel-card:hover, .contact-card:hover{
+      transform:translateY(-4px);
+      border-color:var(--accent);
+      box-shadow:0 10px 34px rgba(0,0,0,.5), 0 0 30px rgba(46,230,255,.35);
+    }
+
+    /* data / mono surfaces */
+    #scholar-box, #quake-panel, .ascii-panel, .mini-3d-caption,
+    .project-step-label, .flip-number, .metric, #readme-container{
+      font-family:var(--font-mono)!important;
+    }
+    .scholar-value{ color:var(--accent-2)!important; }
+    #quake-panel h3{ font-family:var(--font-head); }
+
+    /* tagline + profile */
+    .typewriter{ font-family:var(--font-head); font-weight:500; letter-spacing:.5px; }
+    .profile-photo{ border:2px solid var(--panel-brd); box-shadow:0 0 26px rgba(46,230,255,.35); }
+
+    /* buttons */
+    .carousel-button{ background:linear-gradient(180deg,var(--accent-2),var(--accent)); color:#012; }
+    .carousel-button:hover{ filter:brightness(1.08); background:linear-gradient(180deg,var(--accent-2),var(--accent)); }
+
+    /* accessibility: visible keyboard focus */
+    a:focus-visible, .tab-link:focus-visible, button:focus-visible, .carousel-button:focus-visible{
+      outline:2px solid var(--accent-2); outline-offset:3px; border-radius:8px;
+    }
+
+    /* respect reduced-motion preference */
+    @media (prefers-reduced-motion: reduce){
+      *{ animation-duration:.001ms!important; animation-iteration-count:1!important; transition-duration:.001ms!important; }
+    }
 
   </style>
 </head>


### PR DESCRIPTION
Visual theme refresh for the personal site — for review before going live on `master` (GitHub Pages).

### Changes (single commit on `delta`)
- **Typography**: Inter (body), Space Grotesk (headings / tabs / tagline), JetBrains Mono (data panels)
- **Background**: richer multi-radial space gradient
- **Glass panels**: unified gradient + cyan border + backdrop blur across sections, cards, and side panels
- **States**: refined tab hover/active, card lift on hover
- **Accessibility**: `:focus-visible` outlines + `prefers-reduced-motion` support

Implemented as override rules appended at the end of `<style>`, so the original CSS stays as fallback and no JS hooks/layout are touched.

> ⚠️ Note: `delta` is 264 commits **behind** `master`, so this branch's `index.html` is an older structure than what is currently live. This PR is best used to preview the redesign visually; the same refresh may need to be re-applied on top of `master`'s current `index.html` for a clean merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
