### PR TITLE
Clean up pre-existing console errors (no visual change)

### DIFF
--- a/index.html
+++ b/index.html
@@ -173,11 +173,7 @@
       background-position: center -150px;
       z-index: 1;
       opacity: 0.9;
-
-      -webkit-mask-image: url('./mask-pattern.svg');
-      mask-image: url('./mask-pattern.svg');
-      mask-size: 100% 100%;
-      mask-repeat: no-repeat;
+      /* mask-pattern.svg not present in repo; masking removed to avoid a 404. */
     }
 
     @keyframes windFlag {
@@ -287,18 +283,8 @@
 
     }
 
-    .tabs-background::after {
-      content: "";
-      position: absolute;
-      bottom: 0;
-      left: 0;
-      width: 100%;
-      height: 30px;
-      background: url('torn-edge.png') repeat-x;
-      background-size: contain;
-      pointer-events: none;
-      z-index: 3;
-    }
+    /* .tabs-background::after used torn-edge.png, which is not in the repo (404).
+       Removed the decorative torn-edge overlay rather than ship a broken image ref. */
 
     .tabs-wrapper {
       max-width: var(--tabs-width);
@@ -1960,28 +1946,11 @@
           .pointRadius('size');
       });
 
-    fetch('https://raw.githubusercontent.com/opengeoscience/geo-data/main/volcanoes.json')
-      .then(res => res.json())
-      .then(data => {
-        const volcanoes = data.features.map(v => ({
-          lat: v.geometry.coordinates[1],
-          lng: v.geometry.coordinates[0],
-          name: v.properties.V_Name
-        }));
-
-        world
-          .customLayerData(volcanoes)
-          .customThreeObject(d => {
-            const sprite = new THREE.Sprite(new THREE.SpriteMaterial({
-              color: '#ff4444'
-            }));
-            sprite.scale.set(0.5, 0.5, 0.5); // Adjust size
-            return sprite;
-          })
-          .customThreeObjectUpdate((obj, d) => {
-            obj.position.copy(world.getCoords(d.lat, d.lng));
-          });
-      });
+    // Volcano markers removed: the source
+    // (raw.githubusercontent.com/opengeoscience/geo-data/main/volcanoes.json)
+    // is permanently 404 and threw an uncaught JSON parse error on every load.
+    // To restore, point the fetch at a valid GeoJSON of volcanoes and re-add the
+    // world.customLayerData(...) sprite layer here.
 
   </script>
 
@@ -2039,14 +2008,9 @@
       });
   </script>
 
-  <script>
-    document.addEventListener('DOMContentLoaded', () => {
-      
-
-      updateRGStats();                 // initial
-      setInterval(updateRGStats, 60000); // every 60 seconds
-    });
-  </script>
+  <!-- Scholar metrics are populated by updateScholar() near the end of <body>,
+       which handles the initial load and a 60s refresh. (Removed a dead call to
+       the undefined updateRGStats() that threw a ReferenceError on every load.) -->
 
   <script>
     const traceCanvas = document.getElementById('trace');


### PR DESCRIPTION
Removes pre-existing JavaScript/asset errors surfaced in the browser console. **No visual change** — verified in a headless Chrome render over HTTP.

### Fixes
1. **Dead `updateRGStats()` call** — a leftover `DOMContentLoaded` handler called an undefined function, throwing `ReferenceError` on every page load. The scholar metrics are actually populated by `updateScholar()` (init + 60s refresh), which is untouched. Removed the dead block.
2. **Volcano layer on the globe** — fetched `.../opengeoscience/geo-data/main/volcanoes.json`, which is permanently **404**; calling `res.json()` on the 404 body threw an uncaught JSON parse error each load. Removed the layer and left a comment explaining how to restore it with a valid source.
3. **Missing background images** — dropped CSS references to `torn-edge.png` and `mask-pattern.svg` (both 404, decorative only).

### Verification (headless Chrome, served over HTTP)
- Console: `updateRGStats is not defined` ✅ gone · volcanoes JSON parse error ✅ gone · `torn-edge.png` / `mask-pattern.svg` / `back.png` 404s ✅ gone
- Fonts still load and render: Inter (body), Space Grotesk (headings/tabs/tagline), JetBrains Mono (data panels)
- Scholar box still populates (H-Index 3 / Citations 25 / i10 1); tabs, globe, quake panel all intact

### Known remaining (out of scope — not addressed here)
- `exports is not defined` + "Multiple instances of Three.js" — `three` is loaded twice (standalone unpkg script **and** bundled inside `globe.gl`)
- Null `#slides` / `#commit-list` — dead carousel/commit-list code referencing elements that don't exist
- 404s for images referenced **inside the external GitHub README** rendered in the "GitHub play" tab

Happy to take these on in a follow-up if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
