### PR TITLE
Fix remaining console errors: dup three.js, dead carousel, null commit-list

### DIFF
--- a/index.html
+++ b/index.html
@@ -1678,49 +1678,30 @@
 
 
   <script>
-    fetch('https://api.github.com/repos/debajeet123/Geological_feature_tool/commits')
-      .then(response => response.json())
-      .then(data => {
-        const list = document.getElementById('commit-list');
-        data.slice(0, 5).forEach(commit => {
-          const item = document.createElement('li');
-          item.innerHTML = `
-            <a href="${commit.html_url}" target="_blank">
-              ${commit.commit.message.split('\n')[0]} – <em>${commit.commit.author.name}</em>
-            </a>
-          `;
-          list.appendChild(item);
-        });
-      });
-
-
-    let currentSlide = 0;
-
-    function showSlide(index) {
-      const slides = document.getElementById('slides');
-      const totalSlides = slides.children.length;
-      currentSlide = (index + totalSlides) % totalSlides;
-      slides.style.transform = `translateX(-${currentSlide * 100}%)`;
+    // Recent-commits list — only fetch if the target element exists on this page.
+    // (Previously this ran unconditionally and appended to a null #commit-list,
+    //  producing an uncaught promise error on every load.)
+    if (document.getElementById('commit-list')) {
+      fetch('https://api.github.com/repos/debajeet123/Geological_feature_tool/commits')
+        .then(response => response.json())
+        .then(data => {
+          const list = document.getElementById('commit-list');
+          data.slice(0, 5).forEach(commit => {
+            const item = document.createElement('li');
+            item.innerHTML = `
+              <a href="${commit.html_url}" target="_blank">
+                ${commit.commit.message.split('\n')[0]} – <em>${commit.commit.author.name}</em>
+              </a>
+            `;
+            list.appendChild(item);
+          });
+        })
+        .catch(() => {});
     }
 
-    function nextSlide() {
-      showSlide(currentSlide + 1);
-    }
-
-    function prevSlide() {
-      showSlide(currentSlide - 1);
-    }
-    function showSlide(index) {
-      const slides = document.getElementById('slides');
-      const totalSlides = slides.children.length;
-      currentSlide = (index + totalSlides) % totalSlides;
-      slides.style.transform = `translateX(-${currentSlide * 100}%)`;
-      slides.style.transition = 'transform 0.6s ease-in-out';
-    }
-
-    document.addEventListener('DOMContentLoaded', () => showSlide(0));
-
-
+    // Removed dead carousel code (showSlide/nextSlide/prevSlide + a showSlide(0)
+    // call on DOMContentLoaded). It referenced a #slides element that does not
+    // exist, throwing "Cannot read properties of null (reading 'children')".
   </script>
 
 <section id="contact" class="tab-section">
@@ -1856,8 +1837,10 @@
       });
     });
   </script>
-  <!-- Globe.gl + Three.js -->
-  <script src="https://unpkg.com/three"></script>
+  <!-- Globe.gl (bundles its own Three.js).
+       The standalone unpkg "three" script was removed: it is a CJS/ESM build that
+       threw "exports is not defined" as a classic <script> and caused a duplicate
+       Three.js instance. No global THREE is used on the page. -->
   <script src="https://unpkg.com/globe.gl"></script>
   <!-- Required for topojson -->
   <script src="https://unpkg.com/topojson@3"></script>


### PR DESCRIPTION
Fixes the three remaining console errors noted in the cleanup pass. **No visual change** — verified in a headless Chrome render served over HTTP.

### Fixes
1. **Duplicate / broken Three.js** — removed the standalone `<script src="https://unpkg.com/three">`. As a classic script it loaded a CJS/ESM build that threw `exports is not defined`, and it collided with the copy bundled inside `globe.gl` ("Multiple instances of Three.js"). No global `THREE` is used anymore (the volcano layer that used it was removed earlier), so `globe.gl`'s bundled copy is sufficient.
2. **Dead carousel** — removed `showSlide`/`nextSlide`/`prevSlide` and the `showSlide(0)` call on `DOMContentLoaded`. They referenced a `#slides` element that doesn't exist, throwing `Cannot read properties of null (reading 'children')`. No markup or `onclick` handler calls these functions.
3. **Null `#commit-list`** — the recent-commits fetch appended to a `#commit-list` element that doesn't exist (uncaught promise error). Now guarded behind an existence check, so it no longer errors and skips the GitHub API call entirely when the element is absent.

### Verification (headless Chrome over HTTP)
- Console: `exports is not defined` ✅ gone · "Multiple instances of Three.js" ✅ gone · `#slides` TypeError ✅ gone · `#commit-list` uncaught promise ✅ gone
- **Globe still renders** — 800×800 WebGL canvas present, `Globe` defined, `THREE` now `undefined` (bundled internally); earthquake spikes intact
- Quake list (20 items) and scholar box (H-Index 3 / Citations 25 / i10 1) unchanged

### Intentionally left (non-errors)
- `wave2d not found` — a benign `console.warn` from an existing self-guard (that canvas isn't on the page)
- Two image 404s from paths **inside the external GitHub README** rendered in the "GitHub play" tab (the README's own relative image links; they 404 on the live site regardless)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
