### PR TITLE
Fix layout: anchor tab panels below header band, scroll internally

### DIFF
--- a/index.html
+++ b/index.html
@@ -1386,6 +1386,28 @@
       *{ animation-duration:.001ms!important; animation-iteration-count:1!important; transition-duration:.001ms!important; }
     }
 
+    /* Layout fix: the tab-section panels were fixed & vertically centered, so on
+       shorter viewports they grew taller than the screen (clipping top & bottom)
+       and their <h1> slid up behind the decorative strata band. Anchor them just
+       below the header band and let them scroll internally instead. */
+    .tab-section{
+      top: 290px;
+      transform: translate(-50%, 0) !important;
+      box-sizing: border-box;
+      max-height: calc(100vh - 305px);
+      overflow-y: auto;
+      overscroll-behavior: contain;
+    }
+    /* inner scroll containers no longer need their own tall cap — let the panel
+       own the scrolling so there's a single, predictable scrollbar */
+    #about .about-scroll, #Publications .about-scroll, #readme-section .about-scroll,
+    #projects .project-deck{
+      max-height: none;
+    }
+    @media (max-width: 600px){
+      .tab-section{ top: 270px; max-height: calc(100vh - 285px); width: 92%; padding: 20px !important; }
+    }
+
   </style>
 </head>
 


### PR DESCRIPTION
Fixes the tab-section panel layout. **+22 lines, CSS only.**

### Problem
The section panels (About / Projects / Publications / GitHub play / Contact) were `position: fixed` and vertically centered (`top: 55%; translate(-50%, -50%)`). On shorter viewports the panel became **taller than the screen**, clipping its top and bottom, and its `<h1>` slid up **behind the decorative strata band**, hiding the section heading.

Measured on a 1440×658 viewport: the About panel was 662px tall (>658), and its "About Me" heading sat at y=122, inside the band's 35–275 range (`h1_hiddenBehindBand: true`).

### Fix
- Anchor panels at `top: 290px` — just below the header band (band bottom ≈ 275) — with horizontal centering only.
- `box-sizing: border-box` + `max-height: calc(100vh - 305px)` + `overflow-y: auto`, so content scrolls **inside** the panel and never clips off-screen.
- Remove the inner scroll containers' own tall `max-height` caps so the panel owns a single, predictable scrollbar.
- Small-screen tweak (≤600px): tighter top offset, padding, and width.

### Verification (headless Chrome, 1440×658)
All five sections now report `top: 290`, `bottom: 643` (≤ viewport), `fits: true`, and `h1Visible: true`. The "About Me" heading renders fully below the band; no occlusion, no clipping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
