### PR TITLE
Tighten the large empty gap under the nav bar

### DIFF
--- a/index.html
+++ b/index.html
@@ -1389,14 +1389,17 @@
     /* Layout fix: the tab-section panels were fixed & vertically centered, so on
        shorter viewports they grew taller than the screen (clipping top & bottom)
        and their <h1> slid up behind the decorative strata band. Anchor them just
-       below the header band and let them scroll internally instead. */
+       under the nav — above the band (z-index) so the heading stays visible —
+       and let them scroll internally, removing the large empty gap up top. */
     .tab-section{
-      top: 290px;
+      top: 150px;
       transform: translate(-50%, 0) !important;
       box-sizing: border-box;
-      max-height: calc(100vh - 305px);
+      max-height: calc(100vh - 172px);
       overflow-y: auto;
       overscroll-behavior: contain;
+      z-index: 60;               /* above the strata band (2) so the h1 isn't hidden */
+      padding: 26px 34px !important;
     }
     /* inner scroll containers no longer need their own tall cap — let the panel
        own the scrolling so there's a single, predictable scrollbar */
@@ -1405,7 +1408,7 @@
       max-height: none;
     }
     @media (max-width: 600px){
-      .tab-section{ top: 270px; max-height: calc(100vh - 285px); width: 92%; padding: 20px !important; }
+      .tab-section{ top: 140px; max-height: calc(100vh - 160px); width: 92%; padding: 18px !important; }
     }
 
   </style>


### PR DESCRIPTION
Removes the large empty space between the nav bar and the content panel.

### Problem
The earlier layout fix (#7) anchored the tab-section panels at `top: 290px` — below the full 240px-tall strata band — which left **~159px of dead space** between the nav and the content, with "About Me" landing ~250px below the nav.

### Fix (CSS only)
- Anchor panels at `top: 150px` (just under the nav) and raise `z-index` above the strata band so the heading stays visible instead of being occluded by it.
- Reduce panel padding to `26px 34px` so the heading sits nearer the top.
- Retune `max-height` and the ≤600px mobile offsets accordingly.

### Verification (headless Chrome, 1440×658)
- Nav-to-panel gap: **159px → 19px**
- All five sections (About / Projects / Publications / GitHub play / Contact): `top: 150`, fit within the viewport, no nav overlap, headings fully visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
